### PR TITLE
fix duplicated passed notify

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,8 +34,9 @@ elixir.extend('jshint', function (src, options) {
       .pipe(notify({
         title: 'Laravel Elixir',
         subtitle: 'JSHint passed.',
-        message: ' ',
-        icon: path.join(__dirname, '../laravel-elixir/icons/pass.png')
+        message: 'JSHint passed',
+        icon: path.join(__dirname, '../laravel-elixir/icons/pass.png'),
+        onLast: true
       }));
   });
 


### PR DESCRIPTION
Hello, currently I get this problem when JSHint passed.
```
$ gulp jshint     
[12:24:57] Using gulpfile ~/Code/tcmb/gulpfile.js
[12:24:57] Starting 'jshint'...
[12:24:57] gulp-notify: [Laravel Elixir]  
[12:24:57] gulp-notify: [Laravel Elixir]  
[12:24:57] gulp-notify: [Laravel Elixir]  
[12:24:57] gulp-notify: [Laravel Elixir]  
[12:24:57] gulp-notify: [Laravel Elixir]  
[12:24:57] gulp-notify: [Laravel Elixir]  
[12:24:57] gulp-notify: [Laravel Elixir]  
[12:24:57] gulp-notify: [Laravel Elixir]  
[12:24:57] gulp-notify: [Laravel Elixir]  
[12:24:57] gulp-notify: [Laravel Elixir]  
[12:24:57] gulp-notify: [Laravel Elixir]  
[12:24:57] gulp-notify: [Laravel Elixir]  
[12:24:57] gulp-notify: [Laravel Elixir]  
[12:24:57] gulp-notify: [Laravel Elixir]  
[12:24:57] gulp-notify: [Laravel Elixir]  
[12:24:57] gulp-notify: [Laravel Elixir]  
[12:24:57] gulp-notify: [Laravel Elixir]  
[12:24:57] gulp-notify: [Laravel Elixir]  
[12:24:57] gulp-notify: [Laravel Elixir]  
[12:24:57] gulp-notify: [Laravel Elixir]  
[12:24:57] gulp-notify: [Laravel Elixir]  
[12:24:57] gulp-notify: [Laravel Elixir]  
[12:24:57] gulp-notify: [Laravel Elixir]  
[12:24:57] gulp-notify: [Laravel Elixir]  
[12:24:57] gulp-notify: [Laravel Elixir]  
[12:24:57] gulp-notify: [Laravel Elixir]  
[12:24:57] Finished 'jshint' after 270 ms
```

The reason is you miss `onLast: true` 

And on Ubuntu, message content is lost in JSHint passed notify. I see the title `Laravel Elixir` only

I fixed them. Please pull code. 
Thank you.